### PR TITLE
Do not send  published message to it's publisher(author)

### DIFF
--- a/index.js
+++ b/index.js
@@ -423,7 +423,7 @@ AGSimpleBroker.prototype.transmitPublish = async function (channelName, data, su
   let subscriberClients = this._clientSubscribers[channelName] || {};
 
   Object.keys(subscriberClients).forEach((i) => {
-    if (meta && meta.author !== i) {
+    if (meta.author !== i) {
       subscriberClients[i].transmit('#publish', packet, transmitOptions);
     }
   });

--- a/index.js
+++ b/index.js
@@ -400,7 +400,7 @@ AGSimpleBroker.prototype.invokePublish = async function (channelName, data, supp
   return this.transmitPublish(channelName, data, suppressEvent, meta);
 };
 
-AGSimpleBroker.prototype.transmitPublish = async function (channelName, data, suppressEvent, meta) {
+AGSimpleBroker.prototype.transmitPublish = async function (channelName, data, suppressEvent, meta = {}) {
   let packet = {
     channel: channelName,
     data
@@ -423,7 +423,7 @@ AGSimpleBroker.prototype.transmitPublish = async function (channelName, data, su
   let subscriberClients = this._clientSubscribers[channelName] || {};
 
   Object.keys(subscriberClients).forEach((i) => {
-    if (meta.author !== i) {
+    if (meta && meta.author !== i) {
       subscriberClients[i].transmit('#publish', packet, transmitOptions);
     }
   });

--- a/index.js
+++ b/index.js
@@ -396,11 +396,11 @@ AGSimpleBroker.prototype.setCodecEngine = function (codec) {
 
 // In this implementation of the broker engine, both invokePublish and transmitPublish
 // methods are the same. In alternative implementations, they could be different.
-AGSimpleBroker.prototype.invokePublish = async function (channelName, data, suppressEvent) {
-  return this.transmitPublish(channelName, data, suppressEvent);
+AGSimpleBroker.prototype.invokePublish = async function (channelName, data, suppressEvent, meta) {
+  return this.transmitPublish(channelName, data, suppressEvent, meta);
 };
 
-AGSimpleBroker.prototype.transmitPublish = async function (channelName, data, suppressEvent) {
+AGSimpleBroker.prototype.transmitPublish = async function (channelName, data, suppressEvent, meta) {
   let packet = {
     channel: channelName,
     data
@@ -423,7 +423,9 @@ AGSimpleBroker.prototype.transmitPublish = async function (channelName, data, su
   let subscriberClients = this._clientSubscribers[channelName] || {};
 
   Object.keys(subscriberClients).forEach((i) => {
-    subscriberClients[i].transmit('#publish', packet, transmitOptions);
+    if (meta.author !== i) {
+      subscriberClients[i].transmit('#publish', packet, transmitOptions);
+    }
   });
 
   if (!suppressEvent) {

--- a/index.js
+++ b/index.js
@@ -423,7 +423,7 @@ AGSimpleBroker.prototype.transmitPublish = async function (channelName, data, su
   let subscriberClients = this._clientSubscribers[channelName] || {};
 
   Object.keys(subscriberClients).forEach((i) => {
-    if (meta.author !== i) {
+    if (meta.author !== i) { // skip the author who invoked this publish event
       subscriberClients[i].transmit('#publish', packet, transmitOptions);
     }
   });

--- a/index.js
+++ b/index.js
@@ -52,12 +52,12 @@ SimpleExchange.prototype._triggerChannelUnsubscribe = function (channel) {
   }
 };
 
-SimpleExchange.prototype.transmitPublish = async function (channelName, data) {
-  return this._broker.transmitPublish(channelName, data);
+SimpleExchange.prototype.transmitPublish = async function (channelName, data, suppressEvent, meta) {
+  return this._broker.transmitPublish(channelName, data, suppressEvent, meta);
 };
 
-SimpleExchange.prototype.invokePublish = async function (channelName, data) {
-  return this._broker.invokePublish(channelName, data);
+SimpleExchange.prototype.invokePublish = async function (channelName, data, suppressEvent, meta) {
+  return this._broker.invokePublish(channelName, data, suppressEvent, meta);
 };
 
 SimpleExchange.prototype.subscribe = function (channelName) {


### PR DESCRIPTION
If user1 subscribe channel "test", and then publish message to "test", does user1 receive message that he just sent ? If the answer is "YES", 
can I have any method to make user1 not to receive any data that he just published ?
https://github.com/SocketCluster/socketcluster/issues/54

We can add author details from socketcluster-server(https://github.com/SocketCluster/socketcluster-server/blob/7cc8f3d824a86e91e4b072f263c66788220b280c/serversocket.js#L762-L767) and pass to the broker.

like:

```
 if (isPublish) {
      if (!packet.data) {
        packet.data = {};
      }
      packet.data.data = newData;
      if (!packet.meta) { 
        packet.meta = {};
      }
      packet.meta.author = this.id;
      await this._processInboundPublishPacket(packet);
  }
```
Also we can add some flag while configuring scc-worker, if flag is true then only it will work.

@jondubois can we add this??